### PR TITLE
Allow Variable use text as Value

### DIFF
--- a/tests/vertical_playground.html
+++ b/tests/vertical_playground.html
@@ -741,8 +741,8 @@
            <shadow type="data_variablemenu"></shadow>
           </value>
           <value name="VALUE">
-            <shadow type="math_number">
-              <field name="NUM">0</field>
+            <shadow type="text">
+              <field name="TEXT">0</field>
             </shadow>
           </value>
         </block>


### PR DESCRIPTION
In Scratch 2.0, you can set text at "set variable to [value]" block
In Scratch Blocks, it only accept numbers
Well, i made this PR to allow variables to accept text like Scratch 2.0

(Remember: I don't know if this is a feature or a bug '_')